### PR TITLE
Fix Roadpaint scrolling

### DIFF
--- a/src/main/java/com/bidahochi/BlockMod/blocks/roadpaints/BlockContainer/IScrollRoadPaintBlock.java
+++ b/src/main/java/com/bidahochi/BlockMod/blocks/roadpaints/BlockContainer/IScrollRoadPaintBlock.java
@@ -1,0 +1,12 @@
+package com.bidahochi.BlockMod.blocks.roadpaints.BlockContainer;
+
+import com.bidahochi.BlockMod.blocks.roadpaints.EnumRoadShapes;
+
+import java.util.LinkedHashMap;
+
+public interface IScrollRoadPaintBlock
+{
+    LinkedHashMap<EnumRoadShapes, String> getShapeTextures();
+
+    void SetCurrentShape(EnumRoadShapes enumRoadShapes);
+}

--- a/src/main/java/com/bidahochi/BlockMod/blocks/roadpaints/BlockContainer/ScrollRoadPaintBlock.java
+++ b/src/main/java/com/bidahochi/BlockMod/blocks/roadpaints/BlockContainer/ScrollRoadPaintBlock.java
@@ -23,11 +23,12 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 
-public abstract class ScrollRoadPaintBlock extends BlockContainer {
+import static com.bidahochi.BlockMod.utils.HelperUtils.getValueByIndex;
+
+public abstract class ScrollRoadPaintBlock extends BlockContainer implements IScrollRoadPaintBlock
+{
     public String offset;
     public String color;
     //public HashMap<EnumRoadShapes, IIcon> icons = new HashMap<>();
@@ -44,7 +45,13 @@ public abstract class ScrollRoadPaintBlock extends BlockContainer {
         setCreativeTab(FoxBlocks.foxBlocksCreativeTabRoadRail);
     }
 
-    public LinkedHashMap<EnumRoadShapes, String> getShapeTextures() {
+    public void SetCurrentShape(EnumRoadShapes enumRoadShape)
+    {
+        currentShape = enumRoadShape;
+    }
+
+    public LinkedHashMap<EnumRoadShapes, String> getShapeTextures()
+    {
         return shapeTextures;
     }
 
@@ -82,7 +89,7 @@ public abstract class ScrollRoadPaintBlock extends BlockContainer {
         }
         else {
             int dir = getDir(entity);
-            String shape = shapeTextures.get(EnumRoadShapes.values()[stack.getItemDamage()]);
+            String shape = getValueByIndex(shapeTextures, stack.getItemDamage());
             EnumRoadShapes s = currentShape==null? EnumRoadShapes.straight:currentShape;
             if (entity.isSneaking()) {
                 switch (s) {

--- a/src/main/java/com/bidahochi/BlockMod/blocks/roadpaints/EnumRoadShapes.java
+++ b/src/main/java/com/bidahochi/BlockMod/blocks/roadpaints/EnumRoadShapes.java
@@ -1,6 +1,7 @@
 package com.bidahochi.BlockMod.blocks.roadpaints;
 
-public enum EnumRoadShapes {
+public enum EnumRoadShapes
+{
     //regular lines
     straight("straight", "straight"),
     turn("turn", "turn"),
@@ -31,8 +32,6 @@ public enum EnumRoadShapes {
         this.type = type;
         this.shortName = shortName;
     }
-
-
 }
 
 

--- a/src/main/java/com/bidahochi/BlockMod/core/handler/MouseEventListener.java
+++ b/src/main/java/com/bidahochi/BlockMod/core/handler/MouseEventListener.java
@@ -1,5 +1,6 @@
 package com.bidahochi.BlockMod.core.handler;
 
+import com.bidahochi.BlockMod.blocks.roadpaints.BlockContainer.IScrollRoadPaintBlock;
 import com.bidahochi.BlockMod.blocks.roadpaints.BlockContainer.ScrollRoadPaintBlock;
 import com.bidahochi.BlockMod.network.PacketRPBSelect;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -28,7 +29,7 @@ public class MouseEventListener {
             if (entityPlayer != null && entityPlayer.isSneaking()) {
                 ItemStack itemStack = entityPlayer.getHeldItem();
                 if (itemStack != null && itemStack.getItem() instanceof ItemBlock &&
-                        Block.getBlockFromItem(itemStack.getItem()) instanceof ScrollRoadPaintBlock) {
+                        Block.getBlockFromItem(itemStack.getItem()) instanceof IScrollRoadPaintBlock) {
                     if (System.currentTimeMillis() - lastScroll < 300) { //limit how fast you can scroll through the items
                         event.setCanceled(true);
                         return;

--- a/src/main/java/com/bidahochi/BlockMod/network/PacketRPBSelect.java
+++ b/src/main/java/com/bidahochi/BlockMod/network/PacketRPBSelect.java
@@ -1,7 +1,8 @@
 package com.bidahochi.BlockMod.network;
 
-import com.bidahochi.BlockMod.blocks.roadpaints.BlockContainer.ScrollRoadPaintBlock;
+import com.bidahochi.BlockMod.blocks.roadpaints.BlockContainer.IScrollRoadPaintBlock;
 import com.bidahochi.BlockMod.blocks.roadpaints.EnumRoadShapes;
+import com.bidahochi.BlockMod.utils.HelperUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import net.minecraft.block.Block;
@@ -28,9 +29,10 @@ public class PacketRPBSelect implements IFoxBlocksPacket {
         boolean incDmg = bbis.readBoolean();
         ItemStack itemStack = entityPlayer.inventory.getStackInSlot(slot);
 
-        if (itemStack != null && Block.getBlockFromItem(itemStack.getItem()) instanceof ScrollRoadPaintBlock) {
-
-            int maxDmg = EnumRoadShapes.values().length - 1;
+        if (itemStack != null && Block.getBlockFromItem(itemStack.getItem()) instanceof IScrollRoadPaintBlock)
+        {
+            IScrollRoadPaintBlock theBlock = (IScrollRoadPaintBlock)Block.getBlockFromItem(itemStack.getItem());
+            int maxDmg = theBlock.getShapeTextures().size() - 1;
             int itemDmg = itemStack.getItemDamage();
             itemDmg += incDmg ? 1 : -1;
             if (itemDmg > maxDmg) {
@@ -38,18 +40,19 @@ public class PacketRPBSelect implements IFoxBlocksPacket {
             } else if (itemDmg < 0) {
                 itemDmg = maxDmg;
             }
-            EnumRoadShapes key = EnumRoadShapes.values()[itemDmg];
-            while (!((ScrollRoadPaintBlock)(Block.getBlockFromItem(itemStack.getItem()))).getShapeTextures().containsKey(key)) {
+            EnumRoadShapes key = HelperUtils.getKeyByIndex(theBlock.getShapeTextures(), itemDmg);
+            while (!theBlock.getShapeTextures().containsKey(key))
+            {
                 itemDmg += incDmg ? 1 : -1;
                 if (itemDmg > maxDmg) {
                     itemDmg = 0;
                 } else if (itemDmg < 0) {
                     itemDmg = maxDmg;
                 }
-                key = EnumRoadShapes.values()[itemDmg];
+                key = HelperUtils.getKeyByIndex(theBlock.getShapeTextures(), itemDmg);
             }
             itemStack.setItemDamage(itemDmg);
-            ((ScrollRoadPaintBlock) Block.getBlockFromItem(itemStack.getItem())).currentShape = key;
+            theBlock.SetCurrentShape(key);
         }
     }
     @Override

--- a/src/main/java/com/bidahochi/BlockMod/utils/HelperUtils.java
+++ b/src/main/java/com/bidahochi/BlockMod/utils/HelperUtils.java
@@ -1,0 +1,26 @@
+package com.bidahochi.BlockMod.utils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class HelperUtils
+{
+    public static <K, V> V getValueByIndex(LinkedHashMap<K, V> map, int index) {
+        if (index < 0 || index >= map.size()) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + map.size());
+        }
+
+        ArrayList<Map.Entry<K, V>> entries = new ArrayList<>(map.entrySet());
+        return entries.get(index).getValue();
+    }
+
+    public static <K, V> K getKeyByIndex(LinkedHashMap<K, V> map, int index) {
+        if (index < 0 || index >= map.size()) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + map.size());
+        }
+
+        ArrayList<Map.Entry<K, V>> entries = new ArrayList<>(map.entrySet());
+        return entries.get(index).getKey();
+    }
+}


### PR DESCRIPTION
* Fixed issue with road paint was strictly referencing the enum to get the key number, causing the design to be too rigid